### PR TITLE
add atlas metrics

### DIFF
--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/Constants.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/Constants.java
@@ -1,9 +1,13 @@
 package sg.bigo.bigdata.atlas.monitor;
 
+import java.util.Arrays;
+import java.util.HashSet;
+
 public class Constants {
 
-    public final static String AMBARI_COLLECTOR_PROTOCOL = "http";
+    public final static String HTTP_PROTOCOL = "http";
     public final static String AMBARI_COLLECTOR_RESTAPI = "/ws/v1/timeline/metrics";
+    public final static String ATLAS_METRICS_RESTAPI = "/api/atlas/admin/metrics";
     /**
      * ambari metric protocol, specify component
      */
@@ -42,15 +46,10 @@ public class Constants {
     public final static String LOCAL_HOST = "0.0.0.0";
 
     /**
-     * Presto Api
+     * atlas Api
      */
-    public final static String IS_COORDINATOR = "isCoordinator";
-    public final static String PRESTO_API_PROTOCOL = "http";
-    public final static String PRESTO_API_PORT = "prestoApiPort";
-    public final static String PRESTO_API_INFO = "/v1/info";
-    public final static String PRESTO_API_CLUSTER = "/v1/cluster";
-    public final static String PRESTO_API_QUERY = "/v1/query";
-    public final static String PRESTO_API_WORKER_STATUS = "/v1/status";
-    public final static String PRESTO_TIMEOUT = "prestoTimeout";
+    public final static String ATLAS_API_PORT = "atlasApiPort";
+    public final static String ATLAS_TIMEOUT = "atlasTimeout";
+    public final static HashSet ATLAS_GENERAL_METRICS = new HashSet(Arrays.asList("entityCount", "tagCount", "typeUnusedCount", "typeCount"));
 
 }

--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/Constants.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/Constants.java
@@ -41,15 +41,13 @@ public class Constants {
     public final static String WHITE_LIST_PATTERN_PREFIX = "._p_";
 
     /**
-     *
+     * local host
      */
     public final static String LOCAL_HOST = "0.0.0.0";
 
     /**
      * atlas Api
      */
-    public final static String ATLAS_API_PORT = "atlasApiPort";
-    public final static String ATLAS_TIMEOUT = "atlasTimeout";
     public final static HashSet ATLAS_GENERAL_METRICS = new HashSet(Arrays.asList("entityCount", "tagCount", "typeUnusedCount", "typeCount"));
 
 }

--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/InfoArgs.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/InfoArgs.java
@@ -45,14 +45,6 @@ public class InfoArgs {
      * is coordinator
      */
     private boolean isCoordinator;
-    /**
-     * atlas timeout
-     */
-    private int atlasTimeout;
-    /**
-     * atlas api port
-     */
-    private int atlasApiPort;
 
     public String getAmbariAppId() {
         return ambariAppId;
@@ -148,22 +140,6 @@ public class InfoArgs {
 
     public void setCoordinator(boolean coordinator) {
         isCoordinator = coordinator;
-    }
-
-    public int getAtlasTimeout() {
-        return atlasTimeout;
-    }
-
-    public void setAtlasTimeout(int atlasTimeout) {
-        this.atlasTimeout = atlasTimeout;
-    }
-
-    public int getAtlasApiPort() {
-        return atlasApiPort;
-    }
-
-    public void setAtlasApiPort(int atlasApiPort) {
-        this.atlasApiPort = atlasApiPort;
     }
 
 }

--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/InfoArgs.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/InfoArgs.java
@@ -46,13 +46,13 @@ public class InfoArgs {
      */
     private boolean isCoordinator;
     /**
-     * presto timeout
+     * atlas timeout
      */
-    private int prestoTimeout;
+    private int atlasTimeout;
     /**
-     * presto presto api port
+     * atlas api port
      */
-    private int prestoApiPort;
+    private int atlasApiPort;
 
     public String getAmbariAppId() {
         return ambariAppId;
@@ -150,20 +150,20 @@ public class InfoArgs {
         isCoordinator = coordinator;
     }
 
-    public int getPrestoTimeout() {
-        return prestoTimeout;
+    public int getAtlasTimeout() {
+        return atlasTimeout;
     }
 
-    public void setPrestoTimeout(int prestoTimeout) {
-        this.prestoTimeout = prestoTimeout;
+    public void setAtlasTimeout(int atlasTimeout) {
+        this.atlasTimeout = atlasTimeout;
     }
 
-    public int getPrestoApiPort() {
-        return prestoApiPort;
+    public int getAtlasApiPort() {
+        return atlasApiPort;
     }
 
-    public void setPrestoApiPort(int prestoApiPort) {
-        this.prestoApiPort = prestoApiPort;
+    public void setAtlasApiPort(int atlasApiPort) {
+        this.atlasApiPort = atlasApiPort;
     }
 
 }

--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/jmxtrans/ApiMetricsOutWriter.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/jmxtrans/ApiMetricsOutWriter.java
@@ -38,9 +38,7 @@ public class ApiMetricsOutWriter extends BaseOutputWriter {
                                @JsonProperty(AMBARI_COLLECTOR_PORT) int collectorPort,
                                @JsonProperty(JMX_WHITELIST_ATTRS_FILE) String jmxWhitelistAttrsFile,
                                @JsonProperty(EMIT_METRICS_SWITCH) boolean emitMetricsSwitch,
-                               @JsonProperty(JMX_TYPE_NAMES_LIST) ImmutableList<String> typeNamesList,
-                               @JsonProperty(ATLAS_TIMEOUT) int atlasTimeout,
-                               @JsonProperty(ATLAS_API_PORT) int atlasApiPort
+                               @JsonProperty(JMX_TYPE_NAMES_LIST) ImmutableList<String> typeNamesList
                             ) {
         super(typeNames, booleanAsNumber, debugEnabled, settings);
         args = new InfoArgs();
@@ -54,8 +52,6 @@ public class ApiMetricsOutWriter extends BaseOutputWriter {
         args.setDebug(debugEnabled);
         args.setJmxWhitelistAttrsFile(jmxWhitelistAttrsFile);
         args.setEmitMetrics(emitMetricsSwitch);
-        args.setAtlasApiPort(atlasApiPort);
-        args.setAtlasTimeout(atlasTimeout);
         if (typeNamesList == null || typeNamesList.isEmpty()) {
             typeNamesList = ImmutableList.of("type", "name");
         }

--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/jmxtrans/ApiMetricsOutWriter.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/jmxtrans/ApiMetricsOutWriter.java
@@ -1,0 +1,86 @@
+package sg.bigo.bigdata.atlas.monitor.jmxtrans;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ValidationException;
+import com.googlecode.jmxtrans.model.output.BaseOutputWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sg.bigo.bigdata.atlas.monitor.InfoArgs;
+import sg.bigo.bigdata.atlas.monitor.metrics.JmxHandler;
+
+import java.net.Inet4Address;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import static sg.bigo.bigdata.atlas.monitor.Constants.*;
+
+public class ApiMetricsOutWriter extends BaseOutputWriter {
+    private final static Logger LOG = LoggerFactory.getLogger(ApiMetricsOutWriter.class);
+
+    private JmxHandler jmxHandler;
+    private InfoArgs args;
+
+    @JsonCreator
+    public ApiMetricsOutWriter(@JsonProperty("typeNames") ImmutableList<String> typeNames,
+                               @JsonProperty("booleanAsNumber") boolean booleanAsNumber,
+                               @JsonProperty("debug") Boolean debugEnabled,
+                               @JsonProperty("settings") Map<String, Object> settings,
+                               @JsonProperty(AMBARI_COLLECTOR_APP_ID) String appId,
+                               @JsonProperty(AMBARI_COLLECTOR_ZK_QUORUM) String zkQuorum,
+                               @JsonProperty(AMBARI_COLLECTOR_ZK_CONN_TRY_COUNT) int zkConnTryCount,
+                               @JsonProperty(AMBARI_COLLECTOR_ZK_CONN_TRY_INTERVAL_MS) int zkConnTryInterval,
+                               @JsonProperty(AMBARI_COLLECTOR_CONN_TIMEOUT) int collectorTimeout,
+                               @JsonProperty(AMBARI_COLLECTOR_PORT) int collectorPort,
+                               @JsonProperty(JMX_WHITELIST_ATTRS_FILE) String jmxWhitelistAttrsFile,
+                               @JsonProperty(EMIT_METRICS_SWITCH) boolean emitMetricsSwitch,
+                               @JsonProperty(JMX_TYPE_NAMES_LIST) ImmutableList<String> typeNamesList,
+                               @JsonProperty(ATLAS_TIMEOUT) int atlasTimeout,
+                               @JsonProperty(ATLAS_API_PORT) int atlasApiPort
+                            ) {
+        super(typeNames, booleanAsNumber, debugEnabled, settings);
+        args = new InfoArgs();
+        args.setAmbariAppId(appId);
+        args.setAmbariZkQuorum(zkQuorum);
+        args.setAmbariZkConnTryCount(zkConnTryCount);
+        args.setAmbariZkConnTryInterval(zkConnTryInterval);
+        args.setAmbariCollectorHttpTimeout(collectorTimeout);
+        args.setAmbariCollectorHttpPort(collectorPort);
+        // if debug is on & log level is debug, the debug msg will be printed
+        args.setDebug(debugEnabled);
+        args.setJmxWhitelistAttrsFile(jmxWhitelistAttrsFile);
+        args.setEmitMetrics(emitMetricsSwitch);
+        args.setAtlasApiPort(atlasApiPort);
+        args.setAtlasTimeout(atlasTimeout);
+        if (typeNamesList == null || typeNamesList.isEmpty()) {
+            typeNamesList = ImmutableList.of("type", "name");
+        }
+        args.setTypeNamesList(typeNamesList);
+    }
+
+    @Override
+    protected void internalWrite(Server server,
+                                 Query query,
+                                 ImmutableList<Result> results) throws Exception {
+        jmxHandler.handleApiResult();
+    }
+
+    @Override
+    public void validateSetup(Server server, Query query) throws ValidationException {
+        args.setObjName(query.getObjectName().toString());
+        String host = server.getHost();
+        if (LOCAL_HOST.equals(host)) {
+            try {
+                host = Inet4Address.getLocalHost().getHostName();
+            } catch (UnknownHostException e) {
+                throw new ValidationException("Can not get local host name", query);
+            }
+        }
+        LOG.info("init JmxHandler, host: " + host + ", objName: " + args.getObjName());
+        jmxHandler = new JmxHandler(host, args);
+    }
+}

--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/metrics/JmxHandler.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/metrics/JmxHandler.java
@@ -72,14 +72,8 @@ public class JmxHandler {
         ArrayList<TimelineMetric> timelineMetrics = new ArrayList<>();
 
         // API metrics
-        if (args.isCoordinator()) {
-            List<TimelineMetric> apiMetrics = buildApiTimelineMetrics();
-            timelineMetrics.addAll(apiMetrics);
-            if (apiMetrics.size() == 0) {
-                LOG.warn("api metric size is 0");
-            }
-        }
-
+        List<TimelineMetric> apiMetrics = buildApiTimelineMetrics();
+        timelineMetrics.addAll(apiMetrics);
         metrics.setMetrics(timelineMetrics);
         if (metrics.getMetrics().size() == 0) {
             LOG.warn("all metric size is 0, return");
@@ -211,8 +205,8 @@ public class JmxHandler {
             }
             TimelineMetric timelineMetric = new TimelineMetric();
             timelineMetric.setMetricName(metricName);
-            timelineMetric.setHostName("hostname");
-            timelineMetric.setAppId("args.getAmbariAppId()");
+            timelineMetric.setHostName(hostname);
+            timelineMetric.setAppId(args.getAmbariAppId());
             timelineMetric.setStartTime(currTimeMillis);
             timelineMetric.setTimestamp(currTimeMillis);
             timelineMetric.setType(metricType.name());

--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/rest/AtlasApi.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/rest/AtlasApi.java
@@ -1,0 +1,64 @@
+package sg.bigo.bigdata.atlas.monitor.rest;
+
+import com.alibaba.fastjson.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class AtlasApi {
+    private final static Logger LOG = LoggerFactory.getLogger(AtlasApi.class);
+
+    public JSONObject getMetrics(String connectUrl, int timeout) {
+        HttpURLConnection connection = null;
+        JSONObject metrics = new JSONObject();
+        try {
+            if (connectUrl == null) {
+                throw new IOException("Unknown URL. Unable to connect to atlas.");
+            }
+            connection = getConnection(connectUrl);
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("Connection", "Keep-Alive");
+            connection.setConnectTimeout(timeout);
+            connection.setReadTimeout(timeout);
+            connection.setDoOutput(true);
+            int statusCode = connection.getResponseCode();
+            if (HttpURLConnection.HTTP_OK == statusCode) {
+                LOG.debug("Fetched metrics from atlas " + connectUrl);
+                BufferedReader bufferedReader = new BufferedReader(
+                        new InputStreamReader(connection.getInputStream(), "UTF-8"));
+                String readLine = null;
+                StringBuffer response = new StringBuffer();
+                while (null != (readLine = bufferedReader.readLine())) {
+                    response.append(readLine);
+                }
+                bufferedReader.close();
+                metrics = JSONObject.parseObject(response.toString());
+            } else {
+                LOG.info("Unable to get metrics from atlas, " + connectUrl + ", " + "statusCode = " + statusCode);
+            }
+            return metrics;
+        } catch (IOException ioe) {
+            StringBuilder errorMessage = new StringBuilder("Unable to connect to atlas, " + connectUrl + "\n");
+            try {
+                if ((connection != null)) {
+                    errorMessage.append(connection.getErrorStream());
+                }
+            } catch (Exception e) {
+                LOG.info("Unable to get metrics from atlas, " + connectUrl + ", " + "error: " + e);
+            }
+            LOG.info(errorMessage.toString(), ioe);
+            return metrics;
+        }
+    }
+
+    private HttpURLConnection getConnection(String spec) throws IOException {
+        return (HttpURLConnection) new URL(spec).openConnection();
+    }
+
+}

--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/sink/MetricsSink.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/sink/MetricsSink.java
@@ -10,7 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sg.bigo.bigdata.atlas.monitor.rest.Sender;
 import sg.bigo.bigdata.atlas.monitor.InfoArgs;
-import sg.bigo.bigdata.atlas.monitor.utils.Utils;
+import sg.bigo.bigdata.atlas.monitor.utils.JmxUtils;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -69,7 +69,7 @@ public class MetricsSink {
             return true;
         }
         String collectorHost = getCurrentCollectorHost();
-        String connectUrl = Utils.getAmbariCollectorUri(collectorHost, args.getAmbariCollectorHttpPort());
+        String connectUrl = JmxUtils.getAmbariCollectorUri(collectorHost, args.getAmbariCollectorHttpPort());
         String jsonData = null;
         LOG.info("EmitMetrics connectUrl = " + connectUrl + ", objName: " + args.getObjName());
         try {

--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/utils/AtlasUtils.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/utils/AtlasUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package sg.bigo.bigdata.atlas.monitor.utils;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * DruidCuratorUtils
+ */
+
+public class AtlasUtils {
+    private static final Logger log = LoggerFactory.getLogger(AtlasUtils.class);
+    private static final ConcurrentMap<String, CuratorFramework> CACHE = new ConcurrentHashMap<String, CuratorFramework>();
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                for (CuratorFramework curator : CACHE.values()) {
+                    try {
+                        curator.close();
+                    }
+                    catch (Exception ex) {
+                        log.error("Error at closing " + curator, ex);
+                    }
+                }
+                CACHE.clear();
+            }
+        }));
+    }
+
+    public static CuratorFramework getCurator(String config) {
+        CuratorFramework curator = CACHE.get(config);
+        if (curator == null) {
+            synchronized (AtlasUtils.class) {
+                curator = CACHE.get(config);
+                if (curator == null) {
+                    RetryPolicy retryPolicy = new ExponentialBackoffRetry(1000, 5);
+                    curator = CuratorFrameworkFactory.builder()
+                            .connectString(config)
+                            .sessionTimeoutMs(5000)
+                            .connectionTimeoutMs(5000)
+                            .retryPolicy(retryPolicy)
+                            .build();
+                    curator.start();
+                    CACHE.put(config, curator);
+                    if (CACHE.size() > 1) {
+                        log.warn("More cthan one singleton exist");
+                    }
+                }
+            }
+        }
+        return curator;
+    }
+
+    public static String getActiveAddress(String config) {
+        final CuratorFramework curator = getCurator(config);
+        String leaderCoorZkPath = "/apache_atlas/active_server_info";
+        String activeAddress = "";
+        try {
+            byte[] bytes = curator.getData().forPath(leaderCoorZkPath);
+            activeAddress = new String(bytes, Charset.forName("UTF-8"));
+        } catch (Exception e) {
+            log.error("get active address failed!", e);
+        }
+        return activeAddress;
+    }
+
+}

--- a/src/main/java/sg/bigo/bigdata/atlas/monitor/utils/JmxUtils.java
+++ b/src/main/java/sg/bigo/bigdata/atlas/monitor/utils/JmxUtils.java
@@ -2,9 +2,9 @@ package sg.bigo.bigdata.atlas.monitor.utils;
 
 import static sg.bigo.bigdata.atlas.monitor.Constants.*;
 
-public class Utils {
+public class JmxUtils {
     public static String getAmbariCollectorUri(String host, int port) {
-        StringBuilder sb = new StringBuilder(AMBARI_COLLECTOR_PROTOCOL);
+        StringBuilder sb = new StringBuilder(HTTP_PROTOCOL);
         sb.append("://");
         sb.append(host)
           .append(":")
@@ -13,4 +13,9 @@ public class Utils {
         return sb.toString();
     }
 
+    public static String getAtlasMetricsUri(String host) {
+        StringBuilder sb = new StringBuilder(host);
+        sb.append(ATLAS_METRICS_RESTAPI);
+        return sb.toString();
+    }
 }


### PR DESCRIPTION
1 Some metrics have been added, including regular metrics, system metrics, entity metrics, and markup metrics. 
2 These metrics are obtained through the atlas API.
3 The active atlas instance was fetched through Curator.

atlas.metric.general.entityCount:{1581071763659=531526.0}
atlas.metric.general.tagCount:{1581071763659=2.0}
atlas.metric.general.typeUnusedCount:{1581071763659=58.0}
atlas.metric.general.typeCount:{1581071763659=151.0}
atlas.metric.general.ATLAS_HOOK_0.failedMessageCount:{1581071763659=0.0}
atlas.metric.general.ATLAS_HOOK_0.offsetCurrent:{1581071763659=184.0}
atlas.metric.general.ATLAS_HOOK_0.offsetStart:{1581071763659=183.0}
atlas.metric.general.ATLAS_HOOK_0.processedMessageCount:{1581071763659=1.0}
atlas.metric.tag.tagEntities.sense:{1581071763659=1.0}
atlas.metric.entity.entityActive.__AtlasUserSavedSearch:{1581071763659=1.0}
atlas.metric.entity.entityActive.hive_table:{1581071763659=33685.0}
atlas.metric.entity.entityActive.__AtlasUserProfile:{1581071763659=1.0}
atlas.metric.entity.entityActive.hive_db:{1581071763659=65.0}
atlas.metric.entity.entityActive.hive_process:{1581071763659=33517.0}
atlas.metric.entity.entityActive.hive_storagedesc:{1581071763659=33685.0}
atlas.metric.entity.entityActive.AtlasGlossary:{1581071763659=1.0}
atlas.metric.entity.entityActive.hdfs_path:{1581071763659=33353.0}
atlas.metric.entity.entityActive.AtlasGlossaryTerm:{1581071763659=1.0}
atlas.metric.entity.entityActive.hive_column_lineage:{1581071763659=18.0}
atlas.metric.entity.entityActive.hive_column:{1581071763659=397024.0}
atlas.metric.entity.entityActive.hive_process_execution:{1581071763659=55.0}
atlas.metric.entity.entityActive.hive_table_ddl:{1581071763659=49.0}
atlas.metric.entity.entityDeleted.hive_storagedesc:{1581071763659=5.0}
atlas.metric.entity.entityDeleted.hive_table:{1581071763659=5.0}
atlas.metric.entity.entityDeleted.hive_column:{1581071763659=55.0}
atlas.metric.entity.entityDeleted.hive_table_ddl:{1581071763659=6.0}
